### PR TITLE
Instructions to retrieve an image over SSH

### DIFF
--- a/CVE-2019-19781-DFIR.md
+++ b/CVE-2019-19781-DFIR.md
@@ -59,6 +59,14 @@ dd if=/dev/ad0s1b | gzip -1 - | ssh user@[IP address] dd of=/[fullpath]/ad0s1b.g
 ```
 (Change partition names as as appropriate `df -h`)
 
+Retrieve an image of the disk over SSH:
+```
+ssh user@[IP address] "shell dd if=/dev/md0 | gzip -1 - " | dd of=/[fullpath]/md0.gz
+ssh user@[IP address] "shell dd if=/dev/ad0s1a | gzip -1 - " | dd of=/[fullpath]/ad0s1a.gz
+ssh user@[IP address] "shell dd if=/dev/ad0s1b | gzip -1 - " | dd of=/[fullpath]/ad0s1b.gz
+```
+Remove gzip if you're concerned about a performance hit on the host, your ouput file will be raw and contain unallocated space from the partition.
+
 Details on how to [mount a FreeBSD image](https://digital-forensics.sans.org/blog/2010/02/10/freebsd-computer-forensic-tips-tricks/).
 
 ### Artifacts related to exploitation


### PR DESCRIPTION
Added instructions to retrieve an image of the disk over SSH as an alternative to initiating an SSH connection from the Netscaler to the destination host.